### PR TITLE
Fix css syntax

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,2 +1,4 @@
+/*
 *= require_tree .
 *= require_self
+*/


### PR DESCRIPTION
Wrong css syntax was breaking during asset precompile in production
environment. This commit attempts to fix that issue