### PR TITLE
Validation on purchase (used_balance + value)

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -14,6 +14,10 @@ class Wallet < ApplicationRecord
     credit_cards.sum(:remaining_limit)
   end
 
+  def used_balance
+    credit_cards.sum(:balance)
+  end
+
   private
 
   def limit_less_than_credit_cards

--- a/app/services/credit_card_service.rb
+++ b/app/services/credit_card_service.rb
@@ -57,7 +57,11 @@ class CreditCardService
 
   def purchase_allowed?
     value = amount_to_be_paid
-    value > 0 && @wallet.limit >= value && @wallet.available_balance >= value
+
+    value > 0 &&
+    @wallet.limit >= value &&
+    @wallet.available_balance >= value &&
+    (@wallet.used_balance + value) <= @wallet.limit
   end
 
   def payment_allowed?(card)


### PR DESCRIPTION
There was an error when a purchase was being made.
The used_balance + the value being used was not being compared to the
actual wallet limit, in that case purchase didnt care for the limit
put in the wallet when making more than one purchase.

This commit attempts to fix this issue by adding one more condition on
`CreditCardService#purchase_allowed?` method